### PR TITLE
Output_as_dict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "djcheckup"
-version = "0.2.6"
+version = "0.3.0"
 description = "DJ Checkup is a security scanner for Django sites."
 readme = "README.md"
 authors = [{ name = "Stuart Maxwell", email = "stuart@amanzi.nz" }]

--- a/src/djcheckup/__init__.py
+++ b/src/djcheckup/__init__.py
@@ -1,5 +1,6 @@
 """DJ Checkup CLI package."""
 
+from djcheckup.outputs import SiteCheckResultDict
 from djcheckup.run import run_checks
 
-__all__ = ["run_checks"]
+__all__ = ["SiteCheckResultDict", "run_checks"]

--- a/src/djcheckup/cli.py
+++ b/src/djcheckup/cli.py
@@ -7,7 +7,7 @@ import typer
 
 from djcheckup.check_defs import all_checks
 from djcheckup.checks import SiteChecker
-from djcheckup.outputs import output_results_as_json, rich_output
+from djcheckup.outputs import rich_output, sitecheck_as_json
 
 app = typer.Typer()
 
@@ -26,6 +26,6 @@ def run_checks(
     results = checker.run_checks(all_checks)
 
     if output_json:
-        rich.print_json(output_results_as_json(results))
+        rich.print_json(sitecheck_as_json(results))
     else:
         rich_output(results)

--- a/src/djcheckup/run.py
+++ b/src/djcheckup/run.py
@@ -5,8 +5,8 @@ from typing import Literal, overload
 import httpx
 
 from djcheckup.check_defs import all_checks
-from djcheckup.checks import SiteChecker, SiteCheckResult
-from djcheckup.outputs import output_results_as_json
+from djcheckup.checks import SiteChecker
+from djcheckup.outputs import SiteCheckResultDict, sitecheck_as_dict, sitecheck_as_json
 
 
 @overload
@@ -14,7 +14,7 @@ def run_checks(
     url: str,
     output_format: Literal["object"] = "object",
     client: httpx.Client | None = None,
-) -> SiteCheckResult: ...
+) -> SiteCheckResultDict: ...
 @overload
 def run_checks(url: str, output_format: Literal["json"], client: httpx.Client | None = None) -> str: ...
 
@@ -23,7 +23,7 @@ def run_checks(
     url: str,
     output_format: Literal["object", "json"] = "object",
     client: httpx.Client | None = None,
-) -> str | SiteCheckResult:
+) -> str | SiteCheckResultDict:
     """Run the DJ Checkup tool.
 
     Args:
@@ -42,7 +42,7 @@ def run_checks(
         raise ValueError(msg)
 
     if output_format == "json":
-        return output_results_as_json(results)
+        return sitecheck_as_json(results)
 
     # Default to object output
-    return results
+    return sitecheck_as_dict(results)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -4,7 +4,6 @@ import httpx
 import pytest
 from typer.testing import CliRunner
 
-from djcheckup.checks import SiteCheckResult
 from djcheckup.cli import app
 from djcheckup.run import run_checks
 
@@ -127,7 +126,9 @@ def test_cli_json_output(mock_perfect_client, monkeypatch):
 def test_run_checks_command(mock_perfect_client):
     """Test the run_checks command with mocked HTTP client."""
     result = run_checks(url, client=mock_perfect_client)
-    assert isinstance(result, SiteCheckResult)
+    assert isinstance(result, dict)
+    assert "url" in result
+    assert "check_results" in result
 
 
 def test_run_checks_command_json(mock_perfect_client):

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "djcheckup"
-version = "0.2.6"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
- Change the output so that a dict is returned instead of a SiteCheckResult. This makes it easier to work with on the consuming side.
- Update tests to work with the new format.