### PR TITLE
Better SameSite check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "djcheckup"
-version = "0.3.0"
+version = "0.4.0"
 description = "DJ Checkup is a security scanner for Django sites."
 readme = "README.md"
 authors = [{ name = "Stuart Maxwell", email = "stuart@amanzi.nz" }]

--- a/src/djcheckup/check_defs.py
+++ b/src/djcheckup/check_defs.py
@@ -75,12 +75,13 @@ Reference:
 csrf_samesite_check = CookieSameSiteCheck(
     check_id="csrf_samesite_check",
     depends_on="csrf_check",
-    name="Is the CSRF cookie SameSite=Lax?",
+    name="Does the CSRF cookie have a SameSite flag?",
     cookie_name="csrftoken",
-    samesite_value="Lax",
     success=True,
     severity=SeverityWeight.HIGH,
-    success_message="CSRF cookie is marked as SameSite=Lax, which helps prevent CSRF attacks via cross-site requests.",
+    success_message="""
+CSRF cookie is marked as SameSite=Lax or SameSite=Strict, which helps prevent CSRF attacks via cross-site requests.
+    """,
     failure_message="""
 Your CSRF cookie is not marked as SameSite=Lax. This increases the risk of CSRF attacks.
 Set `CSRF_COOKIE_SAMESITE = 'Lax'` in your Django settings.
@@ -263,12 +264,11 @@ Reference:
 sessionid_samesite_check = CookieSameSiteCheck(
     check_id="sessionid_samesite_check",
     depends_on="sessionid_cookie_check",
-    name="Is the sessionid cookie SameSite=Lax?",
+    name="Does the sessionid cookie have a SameSite flag?",
     cookie_name="sessionid",
-    samesite_value="Lax",
     success=True,
     severity=SeverityWeight.HIGH,
-    success_message="Sessionid cookie is marked as SameSite=Lax. This helps prevent CSRF attacks.",
+    success_message="Sessionid cookie is marked as SameSite=Lax or SameSite=Strict. This helps prevent CSRF attacks.",
     failure_message="""
 Your sessionid cookie is not marked as SameSite=Lax. This increases the risk of CSRF attacks.
 Set `SESSION_COOKIE_SAMESITE = 'Lax'` in your Django settings.

--- a/src/djcheckup/checks.py
+++ b/src/djcheckup/checks.py
@@ -174,10 +174,14 @@ class CookieHttpOnlyCheck(_BaseCheck):
 
 @dataclass
 class CookieSameSiteCheck(_BaseCheck):
-    """A cookie SameSite check."""
+    """A cookie SameSite check.
+
+    Checks that the cookie has the expected SameSite value.
+    If the `samesite_value` is omitted, then it checks if the value is set to Lax or Strict.
+    """
 
     cookie_name: str
-    samesite_value: Literal["Strict", "Lax", "None"]
+    samesite_value: Literal["Strict", "Lax", "None"] | None = None
 
     def check(self, context: SiteCheckContext) -> bool:
         """Check if a specific cookie has a SameSite attribute."""
@@ -186,6 +190,9 @@ class CookieSameSiteCheck(_BaseCheck):
 
         for cookie in context.cookies:
             if cookie.name == self.cookie_name:
+                if not self.samesite_value:
+                    return cookie.get_nonstandard_attr("SameSite") in ["Lax", "Strict"]
+
                 return cookie.get_nonstandard_attr("SameSite") == self.samesite_value
 
         return False

--- a/tests/test_check_types.py
+++ b/tests/test_check_types.py
@@ -367,6 +367,42 @@ def test_cookie_httponly_check_missing_cookie(context):
     assert cookie_httponly_check_missing_cookie.check(context) is False
 
 
+def test_cookie_samesite_check(context):
+    """Test the cookie SameSite check where no attribute is given.
+
+    This will check if the value is set to Lax or Strict.
+    """
+    cookie_samesite_check = CookieSameSiteCheck(
+        check_id="cookie_samesite_check",
+        name="Test Cookie SameSite Check",
+        cookie_name="test-complex-cookie2",
+        success=True,
+        severity=SeverityWeight.MEDIUM,
+        success_message="Test success message",
+        failure_message="""Test failure message""",
+    )
+
+    assert cookie_samesite_check.check(context) is True
+
+
+def test_cookie_samesite_check_empty(context_empty):
+    """Test the cookie SameSite check where no attribute is given.
+
+    This will check if the value is set to Lax or Strict.
+    """
+    cookie_samesite_check_empty = CookieSameSiteCheck(
+        check_id="cookie_samesite_check_empty",
+        name="Test Cookie SameSite Check",
+        cookie_name="test-complex-cookie2",
+        success=True,
+        severity=SeverityWeight.MEDIUM,
+        success_message="Test success message",
+        failure_message="""Test failure message""",
+    )
+
+    assert cookie_samesite_check_empty.check(context_empty) is False
+
+
 def test_cookie_samesite_strict_check(context):
     """Test the cookie SameSite check where the cookie is marked as SameSite=Strict."""
     cookie_samesite_strict_check = CookieSameSiteCheck(

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "djcheckup"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
The cookie SameSite check can now be used to check for the presence of a valid SameSite flag, i.e. either Lax or Strict.

- Changed the CookieSameSiteCheck so that the `samesite_value` is optional. If this is not provided, then the check will look for either Lax or Strict.
- Updated tests for the new check logic
- Updated the built-in checks to use this logic and look for either Lax or Strict.