### PR TITLE
Better HTTPX error checkingq

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "djcheckup"
-version = "0.4.1"
+version = "0.4.2"
 description = "DJ Checkup is a security scanner for Django sites."
 readme = "README.md"
 authors = [{ name = "Stuart Maxwell", email = "stuart@amanzi.nz" }]

--- a/src/djcheckup/checks.py
+++ b/src/djcheckup/checks.py
@@ -385,12 +385,12 @@ Error message:
             response = self.client.get(self.url)
             response.raise_for_status()
 
-        except (httpx.HTTPStatusError, httpx.ConnectError) as e:
+        except (httpx.RequestError, httpx.HTTPStatusError) as e:
             return CheckResponse(
                 name=check_name,
                 result=CheckResult.FAILURE,
                 severity_score=severity_weight,
-                message=f"{error_message} ```\n{e}```",
+                message=f"{error_message} ```\n\n> {e}```",
             )
 
         self.context = create_context(self.url, self.client, response)

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "djcheckup"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Should've read the docs... <https://www.python-httpx.org/quickstart/#exceptions>

- Check for `RequestError` and `HTTPStatusError` exxceptions
- I may improve on this in the future, but it's OK for now.