### PR TITLE
Remove httpx

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ After a few seconds, you'll see a nicely formatted report in your terminal:
 ## Advanced Usage
 
 If you are trying to scan a website that uses a self-signed SSL certificate, or has another SSL issue that you want to
-ignore, you can pass the `--insecure` flag to the command. This tells the HTTPX client to ignore SSL errors.
+ignore, you can pass the `--insecure` flag to the command. This tells the HTTP client to ignore SSL errors.
 
 If you want to return the output in JSON format, you can pass the `--output-json` flag to the command. This will output a
 JSON response in your terminal which can be copied/pasted or piped into a file or other tools.
@@ -123,9 +123,12 @@ from djcheckup import run_checks
 result = run_checks("https://example.com")
 ```
 
-When using `djcheckup` programmatically, you can swap out the HTTPX client with your own client with any specific
-configuration you require. You can also change the output to return a JSON string response. See `api.py` for
-implementation details.
+When using `djcheckup` programmatically, you can swap out the HTTP client with your own client with any specific
+configuration you require. By default, DJ Checkup uses the [HTTPXYZ](https://httpxyz.org/) library which is a fork of
+[HTTPX](https://www.python-httpx.org/). You can create your own client (either HTTPX or HTTPXYZ) with your own
+customisations and pass it to the `run_checks` method.
+
+You can also change the output to return a JSON string response. See `api.py` for implementation details.
 
 A full example could look like the following, which uses a custom HTTPX client and returns JSON:
 
@@ -142,6 +145,8 @@ client = httpx.Client(
 )
 
 result = run_checks("https://example.com", client=client, output_format="json")
+
+print(result)
 ```
 
 [![Published on Django Packages](https://img.shields.io/badge/Published%20on-Django%20Packages-0c3c26)](https://djangopackages.org/packages/p/djcheckup/)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:1ea5faadbf9b00bbe1bca9f85a4bc42a8a717dd179c37807a963adaf20513dc1"
+content_hash = "sha256:56655b618070988ad912994f067ae2dc049fd5fc559b9d4d51b1e764d9bd47d4"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -26,7 +26,7 @@ name = "anyio"
 version = "4.13.0"
 requires_python = ">=3.10"
 summary = "High-level concurrency and networking framework on top of asyncio or Trio"
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "exceptiongroup>=1.0.2; python_version < \"3.11\"",
     "idna>=2.8",
@@ -64,7 +64,7 @@ name = "certifi"
 version = "2026.2.25"
 requires_python = ">=3.7"
 summary = "Python package for providing Mozilla's CA Bundle."
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"},
     {file = "certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"},
@@ -412,7 +412,7 @@ name = "h11"
 version = "0.16.0"
 requires_python = ">=3.8"
 summary = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -423,7 +423,7 @@ name = "httpcore"
 version = "1.0.9"
 requires_python = ">=3.8"
 summary = "A minimal low-level HTTP client."
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "certifi",
     "h11>=0.16",
@@ -438,7 +438,7 @@ name = "httpx"
 version = "0.28.1"
 requires_python = ">=3.8"
 summary = "The next generation HTTP client."
-groups = ["default"]
+groups = ["dev"]
 dependencies = [
     "anyio",
     "certifi",
@@ -448,6 +448,23 @@ dependencies = [
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[[package]]
+name = "httpxyz"
+version = "0.30.0"
+requires_python = ">=3.9"
+summary = "Friendly fork of the next generation HTTP client."
+groups = ["default"]
+dependencies = [
+    "anyio",
+    "certifi",
+    "httpcore==1.*",
+    "idna",
+]
+files = [
+    {file = "httpxyz-0.30.0-py3-none-any.whl", hash = "sha256:4251f35fc1049acde8b36d46a141241b0ff38f685042f2ee0b32225a4d9a0fae"},
+    {file = "httpxyz-0.30.0.tar.gz", hash = "sha256:e1428daf3d3971a0e3dd66e09badc76549d6b4754aad06a999ba72fbbf4b3ff6"},
 ]
 
 [[package]]
@@ -474,13 +491,13 @@ files = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.12"
 requires_python = ">=3.8"
 summary = "Internationalized Domain Names in Applications (IDNA)"
-groups = ["default"]
+groups = ["default", "dev"]
 files = [
-    {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
-    {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+    {file = "idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67"},
+    {file = "idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254"},
 ]
 
 [[package]]
@@ -553,6 +570,22 @@ files = [
 ]
 
 [[package]]
+name = "nox"
+version = "2026.4.10"
+extras = ["pbs"]
+requires_python = ">=3.9"
+summary = "Flexible test automation."
+groups = ["dev"]
+dependencies = [
+    "nox==2026.4.10",
+    "pbs-installer[all]>=2025.1.6",
+]
+files = [
+    {file = "nox-2026.4.10-py3-none-any.whl", hash = "sha256:082c117627590d9b90aa21f86df89b310b07c5842539524203bcb3c719f116c1"},
+    {file = "nox-2026.4.10.tar.gz", hash = "sha256:2d0af5374f3f37a295428c927d1b04a8182aa01762897d172446dda2f1ce9692"},
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 requires_python = ">=3.8"
@@ -561,6 +594,50 @@ groups = ["dev"]
 files = [
     {file = "packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"},
     {file = "packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"},
+]
+
+[[package]]
+name = "pbs-installer"
+version = "2026.4.7"
+requires_python = ">=3.8"
+summary = "Installer for Python Build Standalone"
+groups = ["dev"]
+files = [
+    {file = "pbs_installer-2026.4.7-py3-none-any.whl", hash = "sha256:462ff5173665251d99013ceef9c9b3b6330f9000e4e05a3b45b3acb457a486f3"},
+    {file = "pbs_installer-2026.4.7.tar.gz", hash = "sha256:0c0a7d44f125bac96de094b8208c76b891ee859c71accce1c0e9ec4d83828de8"},
+]
+
+[[package]]
+name = "pbs-installer"
+version = "2026.4.7"
+extras = ["all"]
+requires_python = ">=3.8"
+summary = "Installer for Python Build Standalone"
+groups = ["dev"]
+dependencies = [
+    "pbs-installer==2026.4.7",
+    "pbs-installer[download,install]",
+]
+files = [
+    {file = "pbs_installer-2026.4.7-py3-none-any.whl", hash = "sha256:462ff5173665251d99013ceef9c9b3b6330f9000e4e05a3b45b3acb457a486f3"},
+    {file = "pbs_installer-2026.4.7.tar.gz", hash = "sha256:0c0a7d44f125bac96de094b8208c76b891ee859c71accce1c0e9ec4d83828de8"},
+]
+
+[[package]]
+name = "pbs-installer"
+version = "2026.4.7"
+extras = ["download", "install"]
+requires_python = ">=3.8"
+summary = "Installer for Python Build Standalone"
+groups = ["dev"]
+dependencies = [
+    "httpx<1,>=0.27.0",
+    "pbs-installer==2026.4.7",
+    "zstandard>=0.21.0",
+]
+files = [
+    {file = "pbs_installer-2026.4.7-py3-none-any.whl", hash = "sha256:462ff5173665251d99013ceef9c9b3b6330f9000e4e05a3b45b3acb457a486f3"},
+    {file = "pbs_installer-2026.4.7.tar.gz", hash = "sha256:0c0a7d44f125bac96de094b8208c76b891ee859c71accce1c0e9ec4d83828de8"},
 ]
 
 [[package]]
@@ -587,7 +664,7 @@ files = [
 
 [[package]]
 name = "pre-commit"
-version = "4.5.1"
+version = "4.6.0"
 requires_python = ">=3.10"
 summary = "A framework for managing and maintaining multi-language pre-commit hooks."
 groups = ["dev"]
@@ -599,8 +676,8 @@ dependencies = [
     "virtualenv>=20.10.0",
 ]
 files = [
-    {file = "pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77"},
-    {file = "pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61"},
+    {file = "pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b"},
+    {file = "pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9"},
 ]
 
 [[package]]
@@ -861,4 +938,96 @@ dependencies = [
 files = [
     {file = "virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac"},
     {file = "virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada"},
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+requires_python = ">=3.9"
+summary = "Zstandard bindings for Python"
+groups = ["dev"]
+files = [
+    {file = "zstandard-0.25.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e59fdc271772f6686e01e1b3b74537259800f57e24280be3f29c8a0deb1904dd"},
+    {file = "zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4d441506e9b372386a5271c64125f72d5df6d2a8e8a2a45a0ae09b03cb781ef7"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:ab85470ab54c2cb96e176f40342d9ed41e58ca5733be6a893b730e7af9c40550"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e05ab82ea7753354bb054b92e2f288afb750e6b439ff6ca78af52939ebbc476d"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:78228d8a6a1c177a96b94f7e2e8d012c55f9c760761980da16ae7546a15a8e9b"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b6bd67528ee8b5c5f10255735abc21aa106931f0dbaf297c7be0c886353c3d0"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4b6d83057e713ff235a12e73916b6d356e3084fd3d14ced499d84240f3eecee0"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9174f4ed06f790a6869b41cba05b43eeb9a35f8993c4422ab853b705e8112bbd"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:25f8f3cd45087d089aef5ba3848cd9efe3ad41163d3400862fb42f81a3a46701"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3756b3e9da9b83da1796f8809dd57cb024f838b9eeafde28f3cb472012797ac1"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:81dad8d145d8fd981b2962b686b2241d3a1ea07733e76a2f15435dfb7fb60150"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:a5a419712cf88862a45a23def0ae063686db3d324cec7edbe40509d1a79a0aab"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e7360eae90809efd19b886e59a09dad07da4ca9ba096752e61a2e03c8aca188e"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:75ffc32a569fb049499e63ce68c743155477610532da1eb38e7f24bf7cd29e74"},
+    {file = "zstandard-0.25.0-cp310-cp310-win32.whl", hash = "sha256:106281ae350e494f4ac8a80470e66d1fe27e497052c8d9c3b95dc4cf1ade81aa"},
+    {file = "zstandard-0.25.0-cp310-cp310-win_amd64.whl", hash = "sha256:ea9d54cc3d8064260114a0bbf3479fc4a98b21dffc89b3459edd506b69262f6e"},
+    {file = "zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c"},
+    {file = "zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7"},
+    {file = "zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4"},
+    {file = "zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2"},
+    {file = "zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137"},
+    {file = "zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b"},
+    {file = "zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa"},
+    {file = "zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd"},
+    {file = "zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01"},
+    {file = "zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9"},
+    {file = "zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94"},
+    {file = "zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf"},
+    {file = "zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09"},
+    {file = "zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5"},
+    {file = "zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049"},
+    {file = "zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3"},
+    {file = "zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088"},
+    {file = "zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12"},
+    {file = "zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2"},
+    {file = "zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d"},
+    {file = "zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b"},
 ]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:56655b618070988ad912994f067ae2dc049fd5fc559b9d4d51b1e764d9bd47d4"
+content_hash = "sha256:dfefdb8fcf45296dd2ace74309e3d3da8dd898fbcda73db55760698a5ebf0d0a"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -61,13 +61,13 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.4.22"
 requires_python = ">=3.7"
 summary = "Python package for providing Mozilla's CA Bundle."
 groups = ["default", "dev"]
 files = [
-    {file = "certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"},
-    {file = "certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"},
+    {file = "certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"},
+    {file = "certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580"},
 ]
 
 [[package]]
@@ -512,6 +512,94 @@ files = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.9.0"
+requires_python = ">=3.9"
+summary = "Mypyc runtime library"
+groups = ["dev"]
+marker = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "librt-0.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f8e12706dcb8ff6b3ed57514a19e45c49ad00bcd423e87b2b2e4b5f64578443"},
+    {file = "librt-0.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4e3dda8345307fd7306db0ed0cb109a63a2c85ba780eb9dc2d09b2049a931f9c"},
+    {file = "librt-0.9.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:de7dac64e3eb832ffc7b840eb8f52f76420cde1b845be51b2a0f6b870890645e"},
+    {file = "librt-0.9.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22a904cbdb678f7cb348c90d543d3c52f581663d687992fee47fd566dcbf5285"},
+    {file = "librt-0.9.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:224b9727eb8bc188bc3bcf29d969dba0cd61b01d9bac80c41575520cc4baabb2"},
+    {file = "librt-0.9.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e94cbc6ad9a6aeea46d775cbb11f361022f778a9cc8cc90af653d3a594b057ce"},
+    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7bc30ad339f4e1a01d4917d645e522a0bc0030644d8973f6346397c93ba1503f"},
+    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:56d65b583cf43b8cf4c8fbe1e1da20fa3076cc32a1149a141507af1062718236"},
+    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0a1be03168b2691ba61927e299b352a6315189199ca18a57b733f86cb3cc8d38"},
+    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:63c12efcd160e1d14da11af0c46c0217473e1e0d2ae1acbccc83f561ea4c2a7b"},
+    {file = "librt-0.9.0-cp310-cp310-win32.whl", hash = "sha256:e9002e98dcb1c0a66723592520decd86238ddcef168b37ff6cfb559200b4b774"},
+    {file = "librt-0.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:9fcb461fbf70654a52a7cc670e606f04449e2374c199b1825f754e16dacfedd8"},
+    {file = "librt-0.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:90904fac73c478f4b83f4ed96c99c8208b75e6f9a8a1910548f69a00f1eaa671"},
+    {file = "librt-0.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:789fff71757facc0738e8d89e3b84e4f0251c1c975e85e81b152cdaca927cc2d"},
+    {file = "librt-0.9.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1bf465d1e5b0a27713862441f6467b5ab76385f4ecf8f1f3a44f8aa3c695b4b6"},
+    {file = "librt-0.9.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f819e0c6413e259a17a7c0d49f97f405abadd3c2a316a3b46c6440b7dbbedbb1"},
+    {file = "librt-0.9.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0785c2fb4a81e1aece366aa3e2e039f4a4d7d21aaaded5227d7f3c703427882"},
+    {file = "librt-0.9.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:80b25c7b570a86c03b5da69e665809deb39265476e8e21d96a9328f9762f9990"},
+    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d4d16b608a1c43d7e33142099a75cd93af482dadce0bf82421e91cad077157f4"},
+    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:194fc1a32e1e21fe809d38b5faea66cc65eaa00217c8901fbdb99866938adbdb"},
+    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8c6bc1384d9738781cfd41d09ad7f6e8af13cfea2c75ece6bd6d2566cdea2076"},
+    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:15cb151e52a044f06e54ac7f7b47adbfc89b5c8e2b63e1175a9d587c43e8942a"},
+    {file = "librt-0.9.0-cp311-cp311-win32.whl", hash = "sha256:f100bfe2acf8a3689af9d0cc660d89f17286c9c795f9f18f7b62dd1a6b247ae6"},
+    {file = "librt-0.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:0b73e4266307e51c95e09c0750b7ec383c561d2e97d58e473f6f6a209952fbb8"},
+    {file = "librt-0.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:bc5518873822d2faa8ebdd2c1a4d7c8ef47b01a058495ab7924cb65bdbf5fc9a"},
+    {file = "librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4"},
+    {file = "librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d"},
+    {file = "librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f"},
+    {file = "librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27"},
+    {file = "librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2"},
+    {file = "librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b"},
+    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265"},
+    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084"},
+    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8"},
+    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f"},
+    {file = "librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f"},
+    {file = "librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745"},
+    {file = "librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9"},
+    {file = "librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e"},
+    {file = "librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22"},
+    {file = "librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a"},
+    {file = "librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5"},
+    {file = "librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11"},
+    {file = "librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858"},
+    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e"},
+    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0"},
+    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2"},
+    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d"},
+    {file = "librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd"},
+    {file = "librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519"},
+    {file = "librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5"},
+    {file = "librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb"},
+    {file = "librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499"},
+    {file = "librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f"},
+    {file = "librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1"},
+    {file = "librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f"},
+    {file = "librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a"},
+    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f"},
+    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845"},
+    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b"},
+    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b"},
+    {file = "librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9"},
+    {file = "librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e"},
+    {file = "librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f"},
+    {file = "librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4"},
+    {file = "librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228"},
+    {file = "librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54"},
+    {file = "librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71"},
+    {file = "librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938"},
+    {file = "librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3"},
+    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283"},
+    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee"},
+    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c"},
+    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15"},
+    {file = "librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40"},
+    {file = "librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118"},
+    {file = "librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61"},
+    {file = "librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d"},
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 requires_python = ">=3.10"
@@ -534,6 +622,78 @@ groups = ["default"]
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.2"
+requires_python = ">=3.10"
+summary = "Optional static typing for Python"
+groups = ["dev"]
+dependencies = [
+    "librt>=0.8.0; platform_python_implementation != \"PyPy\"",
+    "mypy-extensions>=1.0.0",
+    "pathspec>=1.0.0",
+    "tomli>=1.1.0; python_version < \"3.11\"",
+    "typing-extensions>=4.14.0; python_version >= \"3.15\"",
+    "typing-extensions>=4.6.0; python_version < \"3.15\"",
+]
+files = [
+    {file = "mypy-1.20.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cf5a4db6dca263010e2c7bff081c89383c72d187ba2cf4c44759aac970e2f0c4"},
+    {file = "mypy-1.20.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7b0e817b518bff7facd7f85ea05b643ad8bdcce684cf29784987b0a7c8e1f997"},
+    {file = "mypy-1.20.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97d7b9a485b40f8ca425460e89bf1da2814625b2da627c0dcc6aa46c92631d14"},
+    {file = "mypy-1.20.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e1c12f6d2db3d78b909b5f77513c11eb7f2dd2782b96a3ab6dffc7d44575c99"},
+    {file = "mypy-1.20.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:89dce27e142d25ffbc154c1819383b69f2e9234dc4ed4766f42e0e8cb264ab5c"},
+    {file = "mypy-1.20.2-cp310-cp310-win_amd64.whl", hash = "sha256:f376e37f9bf2a946872fc5fd1199c99310748e3c26c7a26683f13f8bdb756cbd"},
+    {file = "mypy-1.20.2-cp310-cp310-win_arm64.whl", hash = "sha256:6e2b469efd811707bc530fd1effef0f5d6eebcb7fe376affae69025da4b979a2"},
+    {file = "mypy-1.20.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4077797a273e56e8843d001e9dfe4ba10e33323d6ade647ff260e5cd97d9758c"},
+    {file = "mypy-1.20.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cdecf62abcc4292500d7858aeae87a1f8f1150f4c4dd08fb0b336ee79b2a6df3"},
+    {file = "mypy-1.20.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c566c3a88b6ece59b3d70f65bedef17304f48eb52ff040a6a18214e1917b3254"},
+    {file = "mypy-1.20.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0deb80d062b2479f2c87ae568f89845afc71d11bc41b04179e58165fd9f31e98"},
+    {file = "mypy-1.20.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bba9ad231e92a3e424b3e56b65aa17704993425bba97e302c832f9466bb85bac"},
+    {file = "mypy-1.20.2-cp311-cp311-win_amd64.whl", hash = "sha256:baf593f2765fa3a6b1ef95807dbaa3d25b594f6a52adcc506a6b9cb115e1be67"},
+    {file = "mypy-1.20.2-cp311-cp311-win_arm64.whl", hash = "sha256:20175a1c0f49863946ec20b7f63255768058ac4f07d2b9ded6a6b46cfb5a9100"},
+    {file = "mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b"},
+    {file = "mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4"},
+    {file = "mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6"},
+    {file = "mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066"},
+    {file = "mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102"},
+    {file = "mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9"},
+    {file = "mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58"},
+    {file = "mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026"},
+    {file = "mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943"},
+    {file = "mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517"},
+    {file = "mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15"},
+    {file = "mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee"},
+    {file = "mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f"},
+    {file = "mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330"},
+    {file = "mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30"},
+    {file = "mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924"},
+    {file = "mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb"},
+    {file = "mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc"},
+    {file = "mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558"},
+    {file = "mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8"},
+    {file = "mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3"},
+    {file = "mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609"},
+    {file = "mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2"},
+    {file = "mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c"},
+    {file = "mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744"},
+    {file = "mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6"},
+    {file = "mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec"},
+    {file = "mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382"},
+    {file = "mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563"},
+    {file = "mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665"},
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+requires_python = ">=3.8"
+summary = "Type system extensions for programs checked with the mypy type checker."
+groups = ["dev"]
+files = [
+    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
+    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
 ]
 
 [[package]]
@@ -594,6 +754,17 @@ groups = ["dev"]
 files = [
     {file = "packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"},
     {file = "packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"},
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+requires_python = ">=3.9"
+summary = "Utility library for gitignore style pattern matching of file paths."
+groups = ["dev"]
+files = [
+    {file = "pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"},
+    {file = "pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645"},
 ]
 
 [[package]]
@@ -914,7 +1085,6 @@ version = "4.15.0"
 requires_python = ">=3.9"
 summary = "Backported and Experimental Type Hints for Python 3.9+"
 groups = ["default", "dev"]
-marker = "python_version < \"3.13\""
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},

--- a/pdm.toml
+++ b/pdm.toml
@@ -1,0 +1,8 @@
+[strategy]
+save = "compatible"
+
+[venv]
+in_project = true
+
+[python]
+use_venv = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 [dependency-groups]
 dev = [
-    "nox~=2026.4",
+    "nox[pbs]~=2026.4",
     "pre-commit~=4.5",
     "pytest~=9.0",
     "pytest-cov~=7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "pre-commit~=4.5",
     "pytest~=9.0",
     "pytest-cov~=7.1",
+    "mypy~=1.20",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "httpx~=0.28",
     "rich~=15.0",
     "typer~=0.24",
+    "httpxyz~=0.30",
 ]
 license = { file = "LICENSE" }
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "djcheckup"
-version = "0.7.0"
+version = "0.8.0"
 description = "DJ Checkup is a security scanner for Django sites."
 readme = "README.md"
 authors = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,11 +1,15 @@
 line-length = 120
-target-version = "py314"
+target-version = "py310"
 
 [lint]
 select = ["ALL"]
+typing-extensions = false
 
 [lint.extend-per-file-ignores]
-"tests/**" = ["S101", "ANN201", "ANN001", "ARG001", "PT011", "PGH003", "SLF001"]
+"tests/**" = ["S101", "ANN201", "ANN001", "ARG001", "PT011", "PGH003", "SLF001", "ARG002"]
+"protocols.py" = ["D101", "D102", "D105", "ANN401"]
+"checks.py" = ["BLE001"]
+"outputs.py" = ["ANN401"]
 
 [lint.pydocstyle]
 convention = "google" # Accepts: "google", "numpy", or "pep257".

--- a/src/djcheckup/__init__.py
+++ b/src/djcheckup/__init__.py
@@ -5,4 +5,4 @@ from djcheckup.outputs import SiteCheckResultDict
 
 __all__ = ["SiteCheckResultDict", "run_checks"]
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/src/djcheckup/api.py
+++ b/src/djcheckup/api.py
@@ -2,34 +2,57 @@
 
 from typing import Literal, overload
 
-import httpx
-
 from djcheckup.check_defs import all_checks
 from djcheckup.checks import SiteChecker
 from djcheckup.outputs import SiteCheckResultDict, sitecheck_as_dict, sitecheck_as_json
+from djcheckup.protocols import ClientProtocol
 
 
 @overload
 def run_checks(
     url: str,
     output_format: Literal["object"] = "object",
-    client: httpx.Client | None = None,
+    client: ClientProtocol | None = None,
 ) -> SiteCheckResultDict: ...
 @overload
-def run_checks(url: str, output_format: Literal["json"], client: httpx.Client | None = None) -> str: ...
+def run_checks(
+    url: str,
+    output_format: Literal["json"],
+    client: ClientProtocol | None = None,
+) -> str: ...
 
 
 def run_checks(
     url: str,
     output_format: Literal["object", "json"] = "object",
-    client: httpx.Client | None = None,
+    client: ClientProtocol | None = None,
 ) -> str | SiteCheckResultDict:
     """Run the DJ Checkup tool.
 
+    This is the main interface to the DJ Checkup API. The quickest and easiest way to use this method is to just pass
+    a URL, and you will get a `SiteCheckResultDict` object as a response.
+
+    If you prefer to get a JSON response, you can set the `output_format` to `"json"`, and the results will be returned
+    as a JSON string.
+
+    By default, this uses the HTTPXYZ library with the following options:
+
+    ```python
+    httpxyz.Client(
+        headers={"User-Agent": "DJCheckupBot/1.0 (+https://pypi.org/project/djcheckup/)"},
+        timeout=10.0,
+        follow_redirects=True,
+        verify=True,
+    )
+    ```
+
+    You can optionally create your own customized client with either the HTTPXYZ library, or the original HTTPX library,
+    and pass this to the `client` parameter.
+
     Args:
-        url: The URL to check.
-        output_format: The format of the output, either "object" or "json" (default: "object").
-        client: An optional HTTPX client to use for requests.
+        url (str): The URL to check.
+        output_format (str): The format of the output, either "object" or "json" (default: "object").
+        client (ClientProtocol | None): An optional HTTP client to use for requests.
 
     Returns:
         The result of the checks, either as a JSON string or a SiteCheckResult object.

--- a/src/djcheckup/checks.py
+++ b/src/djcheckup/checks.py
@@ -1,13 +1,16 @@
 """Check types."""
 
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from http.cookiejar import CookieJar
+from types import TracebackType
 from typing import Literal
 
-import httpx
+import httpxyz
+
+from djcheckup.protocols import ClientProtocol, ResponseProtocol, UrlProtocol
 
 
 class SeverityWeight(Enum):
@@ -30,14 +33,23 @@ class CheckResult(Enum):
 
 @dataclass
 class SiteCheckContext:
-    """Context object passed to all checks."""
+    """Context object passed to all checks.
 
-    url: httpx.URL
-    client: httpx.Client
-    headers: httpx.Headers
+    Args:
+        url (str): The URL being checked. Note: we use a string here so that the underlying HTTP client can handle it.
+        client (ClientProtocol): The HTTP client to use for requests. Must match the `ClientProtocol` protocol.
+        headers (Mapping[str, str]): The headers retrieved from the first response.
+        cookies (CookieJar): The cookies retrieved from the first response.
+        content (str): The content retrieved from the first response.
+        response_url (UrlProtocol): The URL of the response after any redirects.
+    """
+
+    url: str
+    client: ClientProtocol
+    headers: Mapping[str, str]
     cookies: CookieJar
     content: str
-    response_url: httpx.URL
+    response_url: UrlProtocol
 
 
 @dataclass
@@ -72,11 +84,28 @@ class _BaseCheck(ABC):
 
     @abstractmethod
     def check(self, context: SiteCheckContext) -> bool:
-        """Run the check and return the result."""
+        """This is the check that needs to be run.
+
+        Each check that is created, needs to implement a `check` method that returns a boolean result.
+
+        Args:
+            context: The site check context.
+
+        Returns:
+            True if the check passes, False otherwise.
+        """
         ...
 
     def run(self, context: SiteCheckContext, previous_results: dict[str, CheckResponse]) -> CheckResponse:
-        """Run the header check."""
+        """Run the check.
+
+        Args:
+            context: The site check context.
+            previous_results: A dictionary of previous check results.
+
+        Returns:
+            The check response.
+        """
         if self.depends_on:
             dependent_result = previous_results.get(self.depends_on)
 
@@ -105,7 +134,7 @@ class ContentCheck(_BaseCheck):
     """A content check.
 
     Checks for specific content in the response.
-    Takes an optional path to check a different URL.
+    Takes an optional path to check a specific path appended to the URL.
     """
 
     content: str
@@ -117,7 +146,8 @@ class ContentCheck(_BaseCheck):
 
         if self.path:
             # Append the path to the url
-            new_url = httpx.URL(context.url).join(self.path)
+            # We use httpxyz.URL to manipulate the URL, and then convert back to the str value.
+            new_url = str(httpxyz.URL(context.url).join(self.path))
 
             response = context.client.get(new_url)
             response_content = response.text
@@ -221,7 +251,11 @@ class CookieSecureCheck(_BaseCheck):
 
 @dataclass
 class HeaderCheck(_BaseCheck):
-    """A header check."""
+    """A header check.
+
+    Checks if a specific header name is present.
+    If the header value is provided, also checks if it matches the actual value.
+    """
 
     header_name: str
     header_value: str = ""
@@ -256,14 +290,15 @@ class PathCheck(_BaseCheck):
     def check(self, context: SiteCheckContext) -> bool:
         """Makes a request to the specified path and checks the response."""
         # Append the path to the url using the urlib module
-        new_url = httpx.URL(context.url).join(self.path)
+        new_url: str = str(httpxyz.URL(context.url).join(self.path))
 
         response = context.client.get(new_url)
 
         if self.status_code:
             return response.status_code == self.status_code
 
-        return bool(httpx.codes.is_success(response.status_code))
+        # Use the `codes` shortcut in HTTPXYZ to check the status code
+        return bool(httpxyz.codes.is_success(response.status_code))
 
 
 @dataclass
@@ -282,11 +317,13 @@ class SchemeCheck(_BaseCheck):
     def check(self, context: SiteCheckContext) -> bool:
         """Check if the scheme of the URL in the request matches the final scheme."""
         # If the start scheme matches the original URL scheme, then we don't need a new request.
-        if context.url.scheme == self.start_scheme:
+        # Even if an alternative client has been provided, we use the `URL` methods from HTTPXYZ.
+        url = httpxyz.URL(context.url)
+        if url.scheme == self.start_scheme:
             return context.response_url.scheme == self.end_scheme
 
         # Need to create a new URL with the specified start scheme
-        new_url = context.url.copy_with(scheme=self.start_scheme)
+        new_url = str(httpxyz.URL(context.url).copy_with(scheme=self.start_scheme))
 
         # And make a request to the new URL
         response = context.client.get(new_url)
@@ -294,16 +331,25 @@ class SchemeCheck(_BaseCheck):
         return response.url.scheme == self.end_scheme
 
 
-def create_context(url: httpx.URL, client: httpx.Client, response: httpx.Response) -> SiteCheckContext:
+def create_context(url: str, client: ClientProtocol, response: ResponseProtocol) -> SiteCheckContext:
     """Create a SiteCheckContext context object.
 
+    This function is called by the `first_check` method and is used to gather the response from the first check which
+    is used by the subsequent checks.
+
     Args:
-        url: The URL to check.
-        client: The HTTPX client to use for requests.
-        response: The HTTPX response object from the initial request.
+        url: The URL being checked.
+        client: The HTTP client to use for any new requests.
+        response: The HTTP response object from the initial request.
 
     Returns:
-        A SiteCheckContext object containing the provided parameters.
+        A SiteCheckContext object containing the following fields:
+        - url: The URL being checked.
+        - client: The HTTP client to use for any new requests.
+        - headers: The HTTP headers from the initial response.
+        - cookies: The HTTP cookies from the initial response.
+        - content: The response content as a string.
+        - response_url: The URL of the final response (after any redirects).
     """
     return SiteCheckContext(
         url=url,
@@ -318,34 +364,35 @@ def create_context(url: httpx.URL, client: httpx.Client, response: httpx.Respons
 class SiteChecker:
     """Run all the checks for a given site."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         url: str,
         *,
-        client: httpx.Client | None = None,
-        user_agent: str = "DJCheckupBot/1.0 (+https://pypi.org/project/djcheckup/)",
+        client: ClientProtocol | None = None,
         timeout: float = 10.0,
         follow_redirects: bool = True,
         verify: bool = True,
     ) -> None:
-        """Initialize the SiteChecker with a URL and optional HTTPX client.
+        """Initialize the SiteChecker with a URL and optional HTTP client.
+
+        The HTTP client is defined in the ClientProtocol protocol and by default this will use HTTPXYZ, unless an
+        alternative is provided. The alternative could be a custom HTTPXYZ client, or an HTTPX client will also work.
 
         Args:
-            url: The URL to check.
-            client: An optional HTTPX client to use for requests.
-            user_agent: The User-Agent string to use for requests.
-            timeout: The timeout for requests in seconds.
-            follow_redirects: Whether to follow redirects.
-            verify: Whether to verify SSL certificates.
+            url (str): The URL to check.
+            client (ClientProtocol): An optional HTTP client to use for requests.
+            timeout (float): The timeout for requests in seconds.
+            follow_redirects (bool): Whether to follow redirects.
+            verify (bool): Whether to verify SSL certificates.
         """
-        self.url: httpx.URL = httpx.URL(url)
+        self.url = url
         self._client_provided = client is not None
 
         if client is not None:
             self.client = client
         else:
-            self.client = httpx.Client(
-                headers={"User-Agent": user_agent},
+            self.client = httpxyz.Client(
+                headers={"User-Agent": "DJCheckupBot/1.0 (+https://pypi.org/project/djcheckup/)"},
                 timeout=timeout,
                 follow_redirects=follow_redirects,
                 verify=verify,
@@ -364,46 +411,57 @@ class SiteChecker:
         """Context manager entry."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # noqa: ANN001
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         """Context manager exit."""
         self.close()
 
     def run_first_check(self) -> CheckResponse:
         """Run the first check.
 
-        This connects to the URL using httpx to check connectivity and then saves the page content, headers, and cookies
-        into a context object for the remaining checks.
+        The first check is responsible for checking connectivity to the URL provided, and setting up the initial
+        `SiteCheckContext` context object, which is then used by all subsequent checks.
+
+        The following steps are performed:
+
+        - Create a `CheckResponse` class to return the result of the check. We set the result to failure.
+        - Try a GET request to the URL provided.
+        - If this fails, then modify the CheckResponse message, and return the failed result.
+        - If this succeeds, we create a `SiteCheckContext` object with the response.
+        - The `SiteCheckContext` object is added to the `context` attribute of the `SiteChecker` object.
+        - Then we modify the `CheckResponse` to indicate the success with a successful message and return it.
+
+        Returns:
+            The `CheckResponse` object indicating the result of the check.
         """
-        check_name = "Can I connect to your site?"
-        severity_weight = SeverityWeight.HIGH
-        success_message = "Connected to your site successfully."
-        error_message = """
-Unable to connect to your site and no further checks can be performed.
-
-Error message:
-
-"""
+        check_response = CheckResponse(
+            name="Can I connect to your site?",
+            severity_score=SeverityWeight.HIGH,
+            result=CheckResult.FAILURE,
+            message="",
+        )
 
         try:
             response = self.client.get(self.url)
             response.raise_for_status()
 
-        except (httpx.RequestError, httpx.HTTPStatusError) as e:
-            return CheckResponse(
-                name=check_name,
-                result=CheckResult.FAILURE,
-                severity_score=severity_weight,
-                message=f"{error_message} \n\n> `{e}`",
+        except Exception as e:
+            error_name = type(e).__name__
+            check_response.message = (
+                f"Unable to connect to your site and no further checks can be performed. \n\n> **{error_name}**: `{e}`"
             )
+            return check_response
 
         self.context = create_context(self.url, self.client, response)
 
-        return CheckResponse(
-            name=check_name,
-            result=CheckResult.SUCCESS,
-            severity_score=severity_weight,
-            message=success_message,
-        )
+        check_response.result = CheckResult.SUCCESS
+        check_response.message = "Connected to your site successfully."
+
+        return check_response
 
     def run_checks(self, checks: Sequence[_BaseCheck]) -> SiteCheckResult:
         """Run all checks.
@@ -427,13 +485,16 @@ Error message:
         for check in checks:
             try:
                 result = check.run(self.context, previous_results)
-            except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+
+            except Exception as e:
+                error_name = type(e).__name__
                 result = CheckResponse(
                     name=check.name,
                     result=CheckResult.FAILURE,
                     severity_score=check.severity,
-                    message=f"An error occurred while running this check: \n\n> `{exc}`",
+                    message=f"An error occurred while running this check: \n\n> **{error_name}**: `{e}`",
                 )
+
             site_check_results.check_results.append(result)
             previous_results[check.check_id] = result
 

--- a/src/djcheckup/outputs.py
+++ b/src/djcheckup/outputs.py
@@ -57,7 +57,7 @@ def rich_output(check_results: SiteCheckResult) -> None:
     console.print(Panel(table))
 
 
-def normalize_for_json(obj: Any) -> Any:  # noqa: ANN401
+def normalize_for_json(obj: Any) -> Any:
     """Recursively convert a dict with Enums to a json-serialisable dict.
 
     This is used to convert the SiteCheckResult object to one that can be converted directly to JSON.
@@ -86,7 +86,7 @@ def normalize_for_json(obj: Any) -> Any:  # noqa: ANN401
 
 def sitecheck_as_dict(site_result: SiteCheckResult) -> SiteCheckResultDict:
     """Convert SiteCheckResult into JSON-serialisable dict."""
-    return normalize_for_json(asdict(site_result))  # type: ignore  # noqa: PGH003
+    return normalize_for_json(asdict(site_result))
 
 
 def sitecheck_as_json(site_result: SiteCheckResult) -> str:

--- a/src/djcheckup/protocols.py
+++ b/src/djcheckup/protocols.py
@@ -1,0 +1,42 @@
+"""Protocol definitions for djcheckup."""
+
+from collections.abc import Mapping
+from http.cookiejar import CookieJar
+from typing import Any, Protocol
+
+
+class UrlProtocol(Protocol):
+    def __str__(self) -> str: ...
+
+    @property
+    def scheme(self) -> str: ...
+
+
+class CookiesProtocol(Protocol):
+    @property
+    def jar(self) -> CookieJar: ...
+
+
+class ResponseProtocol(Protocol):
+    @property
+    def status_code(self) -> int: ...
+
+    @property
+    def text(self) -> str: ...
+
+    @property
+    def url(self) -> UrlProtocol: ...
+
+    @property
+    def headers(self) -> Mapping[str, str]: ...
+
+    @property
+    def cookies(self) -> CookiesProtocol: ...
+
+    def raise_for_status(self) -> "ResponseProtocol": ...
+
+
+class ClientProtocol(Protocol):
+    def get(self, url: Any, *args: Any, **kwargs: Any) -> ResponseProtocol: ...
+
+    def close(self) -> None: ...

--- a/tests/test_check_defs.py
+++ b/tests/test_check_defs.py
@@ -1,6 +1,6 @@
 """Tests the check definitions."""
 
-import httpx
+import httpxyz
 import pytest
 
 from djcheckup.check_defs import all_checks
@@ -9,16 +9,16 @@ from djcheckup.checks import CheckResult, SiteChecker
 url = "https://example.com"
 
 
-def mock_perfect_site(request: httpx.Request) -> httpx.Response:
+def mock_perfect_site(request: httpxyz.Request) -> httpxyz.Response:
     """Return a mock response that mimics a perfect Django site."""
     if request.url.path in ["/admin", "/a/b/c/d/e/f/g/h/i/j/xyz/", "/accounts/login"]:
-        return httpx.Response(
+        return httpxyz.Response(
             status_code=404,
             content="Page not found.",
         )
 
     if request.url.scheme == "http":
-        return httpx.Response(
+        return httpxyz.Response(
             status_code=301,
             headers={"Location": str(request.url.copy_with(scheme="https"))},
             request=request,
@@ -31,7 +31,7 @@ def mock_perfect_site(request: httpx.Request) -> httpx.Response:
         ("Set-Cookie", "sessionid=xxx; Path=/; HttpOnly; Secure; SameSite=Lax"),
     ]
 
-    return httpx.Response(
+    return httpxyz.Response(
         status_code=200,
         headers=headers,
         content="Test response content.",
@@ -40,9 +40,9 @@ def mock_perfect_site(request: httpx.Request) -> httpx.Response:
 
 @pytest.fixture
 def mock_client():
-    """Return a mock HTTPX client that returns a successful response with all cookies and headers."""
-    mock_transport = httpx.MockTransport(mock_perfect_site)
-    return httpx.Client(transport=mock_transport, follow_redirects=True)
+    """Return a mock HTTPXYZ client that returns a successful response with all cookies and headers."""
+    mock_transport = httpxyz.MockTransport(mock_perfect_site)
+    return httpxyz.Client(transport=mock_transport, follow_redirects=True)
 
 
 def test_all_checks(mock_client):

--- a/tests/test_check_types.py
+++ b/tests/test_check_types.py
@@ -1,6 +1,6 @@
 """Test the different types of checks."""
 
-import httpx
+import httpxyz
 import pytest
 
 from djcheckup.checks import (
@@ -20,45 +20,45 @@ from djcheckup.checks import (
 url = "https://example.com"
 
 
-def mock_response(request: httpx.Request) -> httpx.Response:
+def mock_response(request: httpxyz.Request) -> httpxyz.Response:
     """Return a fake response for any request."""
     headers = [
         ("test-header-name", "test-header-value"),
         ("Set-Cookie", "test-simple-cookie1=test-val1; Path=/"),
         ("Set-Cookie", "test-complex-cookie2=test-val2; Path=/; HttpOnly; Secure; SameSite=Strict"),
     ]
-    return httpx.Response(
+    return httpxyz.Response(
         status_code=200,
         headers=headers,
         content="Test response content.",
     )
 
 
-def mock_response_404(request: httpx.Request) -> httpx.Response:
+def mock_response_404(request: httpxyz.Request) -> httpxyz.Response:
     """Return a fake response for any request."""
-    return httpx.Response(
+    return httpxyz.Response(
         status_code=404,
         content="Page not found.",
     )
 
 
-def mock_response_redirect_to_https(request: httpx.Request) -> httpx.Response:
+def mock_response_redirect_to_https(request: httpxyz.Request) -> httpxyz.Response:
     """Return a fake response for any request."""
     if request.url.scheme == "http":
-        return httpx.Response(
+        return httpxyz.Response(
             status_code=301,
             headers={"Location": str(request.url.copy_with(scheme="https"))},
             request=request,
         )
-    return httpx.Response(
+    return httpxyz.Response(
         status_code=200,
         content="Test response content.",
     )
 
 
-def mock_empty_response(request: httpx.Request) -> httpx.Response:
+def mock_empty_response(request: httpxyz.Request) -> httpxyz.Response:
     """Return a fake response with no content."""
-    return httpx.Response(
+    return httpxyz.Response(
         status_code=200,
         content="",
     )
@@ -67,57 +67,57 @@ def mock_empty_response(request: httpx.Request) -> httpx.Response:
 @pytest.fixture
 def mock_client():
     """Return a mock HTTP client."""
-    mock_transport = httpx.MockTransport(mock_response)
-    return httpx.Client(transport=mock_transport)
+    mock_transport = httpxyz.MockTransport(mock_response)
+    return httpxyz.Client(transport=mock_transport)
 
 
 @pytest.fixture
 def mock_client_404():
     """Return a mock HTTP client."""
-    mock_transport = httpx.MockTransport(mock_response_404)
-    return httpx.Client(transport=mock_transport)
+    mock_transport = httpxyz.MockTransport(mock_response_404)
+    return httpxyz.Client(transport=mock_transport)
 
 
 @pytest.fixture
 def mock_client_redirect():
     """Return a mock HTTP client."""
-    mock_transport = httpx.MockTransport(mock_response_redirect_to_https)
-    return httpx.Client(transport=mock_transport, follow_redirects=True)
+    mock_transport = httpxyz.MockTransport(mock_response_redirect_to_https)
+    return httpxyz.Client(transport=mock_transport, follow_redirects=True)
 
 
 @pytest.fixture
 def mock_client_empty():
     """Return a mock HTTP client."""
-    mock_transport = httpx.MockTransport(mock_empty_response)
-    return httpx.Client(transport=mock_transport)
+    mock_transport = httpxyz.MockTransport(mock_empty_response)
+    return httpxyz.Client(transport=mock_transport)
 
 
 @pytest.fixture
 def context(mock_client):
     """Create a SiteCheckContext context object."""
     response = mock_client.get(url)
-    return create_context(url=httpx.URL(url), client=mock_client, response=response)
+    return create_context(url=httpxyz.URL(url), client=mock_client, response=response)
 
 
 @pytest.fixture
 def context_404(mock_client_404):
     """Create a SiteCheckContext context object."""
     response = mock_client_404.get(url)
-    return create_context(url=httpx.URL(url), client=mock_client_404, response=response)
+    return create_context(url=httpxyz.URL(url), client=mock_client_404, response=response)
 
 
 @pytest.fixture
 def context_redirect(mock_client_redirect):
     """Create a SiteCheckContext context object."""
     response = mock_client_redirect.get(url)
-    return create_context(url=httpx.URL(url), client=mock_client_redirect, response=response)
+    return create_context(url=httpxyz.URL(url), client=mock_client_redirect, response=response)
 
 
 @pytest.fixture
 def context_empty(mock_client_empty):
     """Create a SiteCheckContext context object."""
     response = mock_client_empty.get(url)
-    return create_context(url=httpx.URL(url), client=mock_client_empty, response=response)
+    return create_context(url=httpxyz.URL(url), client=mock_client_empty, response=response)
 
 
 def test_content_check(context):

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,6 +1,6 @@
 """Tests for the CLI interface."""
 
-import httpx
+import httpxyz
 import pytest
 from typer.testing import CliRunner
 
@@ -11,16 +11,16 @@ from djcheckup.cli import app
 url = "https://example.com"
 
 
-def mock_perfect_site(request: httpx.Request) -> httpx.Response:
+def mock_perfect_site(request: httpxyz.Request) -> httpxyz.Response:
     """Return a mock response that mimics a perfect Django site."""
     if request.url.path in ["/admin", "/a/b/c/d/e/f/g/h/i/j/xyz/", "/accounts/login"]:
-        return httpx.Response(
+        return httpxyz.Response(
             status_code=404,
             content="Page not found.",
         )
 
     if request.url.scheme == "http":
-        return httpx.Response(
+        return httpxyz.Response(
             status_code=301,
             headers={"Location": str(request.url.copy_with(scheme="https"))},
             request=request,
@@ -33,16 +33,16 @@ def mock_perfect_site(request: httpx.Request) -> httpx.Response:
         ("Set-Cookie", "sessionid=xxx; Path=/; HttpOnly; Secure; SameSite=Lax"),
     ]
 
-    return httpx.Response(
+    return httpxyz.Response(
         status_code=200,
         headers=headers,
         content="Test response content.",
     )
 
 
-def mock_response(request: httpx.Request) -> httpx.Response:
+def mock_response(request: httpxyz.Request) -> httpxyz.Response:
     """Return a barebones mock response."""
-    return httpx.Response(
+    return httpxyz.Response(
         status_code=200,
         content="Test response content.",
     )
@@ -50,16 +50,16 @@ def mock_response(request: httpx.Request) -> httpx.Response:
 
 @pytest.fixture
 def mock_perfect_client():
-    """Return a mock HTTPX client that returns a successful response with all cookies and headers."""
-    mock_transport = httpx.MockTransport(mock_perfect_site)
-    return httpx.Client(transport=mock_transport, follow_redirects=True)
+    """Return a mock HTTPXYZ client that returns a successful response with all cookies and headers."""
+    mock_transport = httpxyz.MockTransport(mock_perfect_site)
+    return httpxyz.Client(transport=mock_transport, follow_redirects=True)
 
 
 @pytest.fixture
 def mock_client():
-    """Return a mock HTTPX client that returns a successful barebones response."""
-    mock_transport = httpx.MockTransport(mock_response)
-    return httpx.Client(transport=mock_transport, follow_redirects=True)
+    """Return a mock HTTPXYZ client that returns a successful barebones response."""
+    mock_transport = httpxyz.MockTransport(mock_response)
+    return httpxyz.Client(transport=mock_transport, follow_redirects=True)
 
 
 def test_cli(mock_perfect_client, monkeypatch):
@@ -67,7 +67,7 @@ def test_cli(mock_perfect_client, monkeypatch):
 
     # Mock the SiteChecker to use our mock client
     def mock_site_checker_init(self, url: str, **_kwargs: dict) -> None:
-        self.url = httpx.URL(url)
+        self.url = httpxyz.URL(url)
         self.client = mock_perfect_client
         self._client_provided = True
 
@@ -87,7 +87,7 @@ def test_cli_with_failures(mock_client, monkeypatch):
 
     # Mock the SiteChecker to use our mock client
     def mock_site_checker_init(self, url: str, **_kwargs: object) -> None:
-        self.url = httpx.URL(url)
+        self.url = httpxyz.URL(url)
         self.client = mock_client
         self._client_provided = True
 
@@ -114,10 +114,10 @@ def test_cli_insecure_flag(monkeypatch):
     """
 
     class MockSiteChecker:
-        def __init__(self, url: str, **kwargs: dict) -> None:  # noqa: ARG002
+        def __init__(self, url: str, **kwargs: dict) -> None:
             captured_kwargs.update(kwargs)
 
-        def run_checks(self, checks: list) -> SiteCheckResult:  # noqa: ARG002
+        def run_checks(self, checks: list) -> SiteCheckResult:
             """Just returns an empty SiteCheckResult."""
             return SiteCheckResult(url=url, check_results=[])
 
@@ -150,7 +150,7 @@ def test_cli_json_output(mock_perfect_client, monkeypatch):
 
     # Mock the SiteChecker to use our mock client
     def mock_site_checker_init(self, url: str, **_kwargs: object) -> None:
-        self.url = httpx.URL(url)
+        self.url = httpxyz.URL(url)
         self.client = mock_perfect_client
         self._client_provided = True
 

--- a/tests/test_sitechecker.py
+++ b/tests/test_sitechecker.py
@@ -1,6 +1,6 @@
 """Test the SiteChecker class and related functionality."""
 
-import httpx
+import httpxyz
 import pytest
 
 from djcheckup.checks import CheckResult, PathCheck, SeverityWeight, SiteChecker
@@ -8,22 +8,22 @@ from djcheckup.checks import CheckResult, PathCheck, SeverityWeight, SiteChecker
 url = "https://example.com"
 
 
-def mock_response(request: httpx.Request) -> httpx.Response:
+def mock_response(request: httpxyz.Request) -> httpxyz.Response:
     """Return a fake response for any request."""
     # If the path matches /fail, raise a connection error
     if request.url.path == "/fail":
         msg = "Connection error."
-        raise httpx.ConnectError(msg)
-    return httpx.Response(
+        raise httpxyz.ConnectError(msg)
+    return httpxyz.Response(
         status_code=200,
         headers={"test-header-name": "test-header-value"},
         content="Test response content.",
     )
 
 
-def mock_response_404(request: httpx.Request) -> httpx.Response:
+def mock_response_404(request: httpxyz.Request) -> httpxyz.Response:
     """Return a fake response for any request."""
-    return httpx.Response(
+    return httpxyz.Response(
         status_code=404,
         content="Page not found.",
     )
@@ -32,15 +32,15 @@ def mock_response_404(request: httpx.Request) -> httpx.Response:
 @pytest.fixture
 def mock_client_404():
     """Return a mock HTTP client."""
-    mock_transport = httpx.MockTransport(mock_response_404)
-    return httpx.Client(transport=mock_transport)
+    mock_transport = httpxyz.MockTransport(mock_response_404)
+    return httpxyz.Client(transport=mock_transport)
 
 
 @pytest.fixture
 def mock_client():
     """Return a mock HTTP client."""
-    mock_transport = httpx.MockTransport(mock_response)
-    return httpx.Client(transport=mock_transport)
+    mock_transport = httpxyz.MockTransport(mock_response)
+    return httpxyz.Client(transport=mock_transport)
 
 
 def test_first_check(mock_client):
@@ -95,12 +95,12 @@ def test_second_check_fails(mock_client):
 
 
 def test_sitechecker_init(mock_client, monkeypatch):
-    """Test the SiteChecker class when not getting a custom HTTPX client passed to it."""
+    """Test the SiteChecker class when not getting a custom HTTPXYZ client passed to it."""
 
-    def mock_httpx_client(*_args: object, **_kwargs: object) -> httpx.Client:
+    def mock_httpxyz_client(*_args: object, **_kwargs: object) -> httpxyz.Client:
         return mock_client
 
-    monkeypatch.setattr("httpx.Client", mock_httpx_client)
+    monkeypatch.setattr("httpxyz.Client", mock_httpxyz_client)
 
     checker = SiteChecker(url=url)
     assert checker._client_provided is False
@@ -109,11 +109,11 @@ def test_sitechecker_init(mock_client, monkeypatch):
 
 
 def test_sitechecker_passes_verify_to_client(monkeypatch):
-    """Test that SiteChecker passes the verify parameter to httpx.Client."""
+    """Test that SiteChecker passes the verify parameter to HTTPXYZ.Client."""
     captured_kwargs = {}
 
     """
-    This `MockClient` pretends to be an HTTPX client, but all it does is capture the kwargs passed to it.
+    This `MockClient` pretends to be an HTTPXYZ client, but all it does is capture the kwargs passed to it.
     """
 
     class MockClient:
@@ -123,8 +123,8 @@ def test_sitechecker_passes_verify_to_client(monkeypatch):
         def close(self) -> None:
             pass
 
-    # Patch httpx.Client to capture arguments
-    monkeypatch.setattr("httpx.Client", MockClient)
+    # Patch httpxyz.Client to capture arguments
+    monkeypatch.setattr("httpxyz.Client", MockClient)
 
     # Test default (verify=True)
     captured_kwargs.clear()


### PR DESCRIPTION
- Remove HTTPX as a dependency
- Switch to HTTPXYZ as the HTTP client
- Keep the ability to use a custom HTTPX client, as well as a custom HTTPXYZ client
- New protocol that maps to the features used in HTTPX
- Lots of refactoring to be able to support both HTTPX and HTTPXYZ
- Tidied up some docstrings along the way.